### PR TITLE
fix: add missing peer dependency on rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "dependencies": {
     "del": "^5.1.0"
   },
+  "peerDependencies": {
+    "rollup": "*"
+  },
   "devDependencies": {
     "@babel/core": "^7.10.2",
     "@babel/preset-env": "^7.10.2",


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/vladshcherbin/rollup-plugin-delete/commit/18a747728d8314e6ba62a128730243575cdd786f removed the peer dependency on `rollup` but it's required for the types to be guaranteed access to `rollup`, without it, the plugin relies on hoisting to make `rollup` accesible.

**How did you fix it?**

Add a missing peer dependency on `rollup`